### PR TITLE
Add 'v' prefix for download path

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -46,7 +46,7 @@ download_release() {
   windows) arch="amd64" ;;
   esac
 
-  url="$GH_REPO/releases/download/${version}/ctop-${version}-${platform}-${arch}"
+  url="$GH_REPO/releases/download/v${version}/ctop-${version}-${platform}-${arch}"
 
   echo "* Downloading $TOOL_NAME release $version..."
   curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"


### PR DESCRIPTION
Seems to be enforced by GitHub recently(?)
Doesn't break any previous versions either